### PR TITLE
Melhorar concordância

### DIFF
--- a/xml/System/IDisposable.xml
+++ b/xml/System/IDisposable.xml
@@ -40,7 +40,7 @@
 ## Remarks  
  O principal uso dessa interface é liberar recursos não gerenciados. O coletor de lixo automaticamente libera a memória alocada para um objeto gerenciado quando esse objeto não é mais usado. No entanto, não é possível prever quando ocorrerá a coleta de lixo. Além disso, o coletor de lixo não tem conhecimento dos recursos não gerenciados, como identificadores de janela ou abrir arquivos e fluxos.  
   
- Use o <xref:System.IDisposable.Dispose%2A> método dessa interface explicitamente liberar recursos não gerenciados em conjunto com o coletor de lixo. O consumidor de um objeto pode chamar esse método quando o objeto não for mais necessário.  
+ Use o método <xref:System.IDisposable.Dispose%2A> dessa interface explicitamente para liberar recursos não gerenciados em conjunto com o coletor de lixo. O consumidor de um objeto pode chamar esse método quando o objeto não for mais necessário.  
   
 > [!WARNING]
 >  É uma alteração significativa para adicionar o <xref:System.IDisposable> interface para uma classe existente. Porque já existente de consumidores do seu tipo não é possível chamar <xref:System.IDisposable.Dispose%2A>, você não pode ter certeza de que recursos não gerenciados mantidos pelo seu tipo serão liberados.  


### PR DESCRIPTION
Use o método Dispose dessa interface explicitamente para liberar recursos não gerenciados em conjunto com o coletor de lixo.